### PR TITLE
Reintroduce Firebase callables for order lifecycle

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,4 +1,103 @@
+import * as admin from "firebase-admin";
+import * as functions from "firebase-functions";
+import { createHash, randomBytes } from "crypto";
 import { Client, Wallet, xrpToDrops, EscrowCreate, EscrowFinish, SubmitResponse, TxResponse } from "xrpl";
+
+admin.initializeApp();
+
+const db = admin.firestore();
+const ORDERS_COLLECTION = "orders";
+
+interface EscrowCondition {
+  fulfillment: string;
+  condition: string;
+}
+
+const generateEscrowCondition = (): EscrowCondition => {
+  const fulfillmentBuffer = randomBytes(32);
+  const fulfillment = fulfillmentBuffer.toString("hex").toUpperCase();
+  const condition = createHash("sha256").update(fulfillmentBuffer).digest("hex").toUpperCase();
+
+  return { fulfillment, condition };
+};
+
+const assertAuthenticated = (context: functions.https.CallableContext): void => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError("unauthenticated", "Authentication is required to call this function.");
+  }
+};
+
+function assertString(value: unknown, name: string): asserts value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new functions.https.HttpsError("invalid-argument", `${name} must be a non-empty string.`);
+  }
+}
+
+export const createOrder = functions.https.onCall(async (data, context) => {
+  assertAuthenticated(context);
+
+  const buyerAccount = data?.buyerAccount;
+  const sellerAccount = data?.sellerAccount;
+  const amountXrp = data?.amountXrp;
+  const escrowWalletSeed = data?.escrowWalletSeed;
+
+  assertString(buyerAccount, "buyerAccount");
+  assertString(sellerAccount, "sellerAccount");
+  assertString(amountXrp, "amountXrp");
+  assertString(escrowWalletSeed, "escrowWalletSeed");
+
+  const escrowWallet = Wallet.fromSeed(escrowWalletSeed);
+  const { condition, fulfillment } = generateEscrowCondition();
+
+  const orderRef = db.collection(ORDERS_COLLECTION).doc();
+  const orderRecord = {
+    buyerAccount,
+    sellerAccount,
+    amountXrp,
+    escrowCondition: condition,
+    escrowFulfillment: fulfillment,
+    escrowWallet: escrowWallet.address,
+    status: "pending",
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    createdBy: context.auth.uid,
+  };
+
+  await orderRef.set(orderRecord);
+
+  return {
+    orderId: orderRef.id,
+    escrowCondition: condition,
+    escrowFulfillment: fulfillment,
+    escrowWallet: escrowWallet.address,
+  };
+});
+
+export const completeOrder = functions.https.onCall(async (data, context) => {
+  assertAuthenticated(context);
+
+  const orderId = data?.orderId;
+  const escrowReleaseTxHash = data?.escrowReleaseTxHash;
+
+  assertString(orderId, "orderId");
+  assertString(escrowReleaseTxHash, "escrowReleaseTxHash");
+
+  const orderRef = db.collection(ORDERS_COLLECTION).doc(orderId);
+  const orderSnap = await orderRef.get();
+
+  if (!orderSnap.exists) {
+    throw new functions.https.HttpsError("not-found", "Order not found.");
+  }
+
+  await orderRef.update({
+    status: "completed",
+    escrowReleaseTxHash,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+    completedAt: admin.firestore.FieldValue.serverTimestamp(),
+  });
+
+  return { orderId, status: "completed", escrowReleaseTxHash };
+});
 
 export interface EscrowParams {
   client: Client;


### PR DESCRIPTION
## Summary
- initialize Firebase Admin within the Cloud Functions entry point
- restore callable createOrder and completeOrder handlers with Firestore writes and escrow condition generation
- keep the XRPL escrow helper exported alongside the Firebase callables

## Testing
- `npx tsc --noEmit functions/src/index.ts` *(fails: missing firebase-admin, firebase-functions, crypto, and xrpl type declarations in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cea4bb1dbc832783a99a182aeb6667