### PR TITLE
Make Firebase measurement ID optional

### DIFF
--- a/swift-market/.env.example
+++ b/swift-market/.env.example
@@ -10,4 +10,6 @@ REACT_APP_PROJECT_ID="your-project-id"
 REACT_APP_STORAGE_BUCKET="your-storage-bucket"
 REACT_APP_MESSAGING_SENDER_ID="your-messaging-sender-id"
 REACT_APP_APP_ID="your-app-id"
+# Optional when Firebase Analytics is not enabled.
+# Leave unset to disable analytics locally.
 REACT_APP_MEASUREMENT_ID="your-measurement-id"

--- a/swift-market/src/lib/firebase.ts
+++ b/swift-market/src/lib/firebase.ts
@@ -5,15 +5,25 @@ import { getFirestore } from 'firebase/firestore';
 import { getStorage } from 'firebase/storage';
 import { getFunctions } from 'firebase/functions';
 
+const readEnv = (key: string): string => {
+  const value = process.env[key];
+
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+
+  return value;
+};
+
 // Your web app's Firebase configuration
 const firebaseConfig = {
-  apiKey: process.env.REACT_APP_API_KEY,
-  authDomain: process.env.REACT_APP_AUTH_DOMAIN,
-  projectId: process.env.REACT_APP_PROJECT_ID,
-  storageBucket: process.env.REACT_APP_STORAGE_BUCKET,
-  messagingSenderId: process.env.REACT_APP_MESSAGING_SENDER_ID,
-  appId: process.env.REACT_APP_APP_ID,
-  measurementId: process.env.REACT_APP_MEASUREMENT_ID
+  apiKey: readEnv('REACT_APP_API_KEY'),
+  authDomain: readEnv('REACT_APP_AUTH_DOMAIN'),
+  projectId: readEnv('REACT_APP_PROJECT_ID'),
+  storageBucket: readEnv('REACT_APP_STORAGE_BUCKET'),
+  messagingSenderId: readEnv('REACT_APP_MESSAGING_SENDER_ID'),
+  appId: readEnv('REACT_APP_APP_ID'),
+  measurementId: process.env.REACT_APP_MEASUREMENT_ID ?? undefined
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## Summary
- add a helper to ensure required Firebase environment variables are present during initialization
- tolerate missing Firebase Analytics measurement ID and document that it is optional when analytics is disabled

## Testing
- REACT_APP_API_KEY=a REACT_APP_AUTH_DOMAIN=a REACT_APP_PROJECT_ID=a REACT_APP_STORAGE_BUCKET=a REACT_APP_MESSAGING_SENDER_ID=a REACT_APP_APP_ID=a npm run build >/tmp/build_no_measurement.log
- REACT_APP_API_KEY=a REACT_APP_AUTH_DOMAIN=a REACT_APP_PROJECT_ID=a REACT_APP_STORAGE_BUCKET=a REACT_APP_MESSAGING_SENDER_ID=a REACT_APP_APP_ID=a REACT_APP_MEASUREMENT_ID=b npm run build >/tmp/build_with_measurement.log

------
https://chatgpt.com/codex/tasks/task_e_68cef6cf7cac8327bcf4720f9fb5d132